### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*
-            testbench: 9.*
+            testbench: ^9.10
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3, 8.2]
+        php: [8.5, 8.4, 8.3, 8.2]
         laravel: [12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.2|^8.3|^8.4",
+        "php": "^8.2|^8.3|^8.4|^8.5",
         "guzzlehttp/guzzle": "^7.4",
         "illuminate/contracts": "^11.43|^12.0",
         "spatie/laravel-package-tools": "^1.9.2",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^9.0|^10.0",
+        "orchestra/testbench": "^9.10|^10.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",
         "phpunit/phpunit": "^10.4|^11.5.3"

--- a/src/UsesMinIOServer.php
+++ b/src/UsesMinIOServer.php
@@ -94,7 +94,7 @@ trait UsesMinIOServer
      * @param integer $timeout
      * @return string
      */
-    private function exec(string $cmd, int $timeout = 30): string
+    private function exec(string $cmd, int $timeout = 10): string
     {
         $process = Process::fromShellCommandline($cmd)->setTimeout($timeout);
         $process->run();
@@ -172,7 +172,7 @@ trait UsesMinIOServer
         $region   = config("filesystems.disks.{$this->minIODisk}.region") ?: 'eu-west-1';
         $bucket   = config("filesystems.disks.{$this->minIODisk}.bucket") ?: 'bucket-name';
 
-        $addLocalMinIO = $this->exec("until (mc alias set local {$url} minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;", 60);
+        $addLocalMinIO = $this->exec("until (mc alias set local {$url} minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;");
 
         if (!Str::contains($addLocalMinIO, 'Added `local` successfully.')) {
             $this->fail('Could not configure MinIO server');

--- a/src/UsesMinIOServer.php
+++ b/src/UsesMinIOServer.php
@@ -172,14 +172,14 @@ trait UsesMinIOServer
         $region   = config("filesystems.disks.{$this->minIODisk}.region") ?: 'eu-west-1';
         $bucket   = config("filesystems.disks.{$this->minIODisk}.bucket") ?: 'bucket-name';
 
-        $addLocalMinIO = $this->exec("until (mc config host add local {$url} minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;", 60);
+        $addLocalMinIO = $this->exec("until (mc alias set local {$url} minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;", 60);
 
         if (!Str::contains($addLocalMinIO, 'Added `local` successfully.')) {
             $this->fail('Could not configure MinIO server');
         }
 
         $this->exec("mc admin user add local {$username} {$password}");
-        $this->exec("mc admin policy set local readwrite user={$username}");
+        $this->exec("mc admin policy attach local readwrite --user={$username}");
         $this->exec("mc mb local/{$bucket} --region={$region}");
 
         $this->initMinIOConfigCollection();

--- a/src/UsesMinIOServer.php
+++ b/src/UsesMinIOServer.php
@@ -172,7 +172,7 @@ trait UsesMinIOServer
         $region   = config("filesystems.disks.{$this->minIODisk}.region") ?: 'eu-west-1';
         $bucket   = config("filesystems.disks.{$this->minIODisk}.bucket") ?: 'bucket-name';
 
-        $addLocalMinIO = $this->exec("until (mc config host add local {$url} minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;");
+        $addLocalMinIO = $this->exec("until (mc config host add local {$url} minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;", 30);
 
         if (!Str::contains($addLocalMinIO, 'Added `local` successfully.')) {
             $this->fail('Could not configure MinIO server');

--- a/src/UsesMinIOServer.php
+++ b/src/UsesMinIOServer.php
@@ -94,7 +94,7 @@ trait UsesMinIOServer
      * @param integer $timeout
      * @return string
      */
-    private function exec(string $cmd, int $timeout = 10): string
+    private function exec(string $cmd, int $timeout = 30): string
     {
         $process = Process::fromShellCommandline($cmd)->setTimeout($timeout);
         $process->run();
@@ -172,7 +172,7 @@ trait UsesMinIOServer
         $region   = config("filesystems.disks.{$this->minIODisk}.region") ?: 'eu-west-1';
         $bucket   = config("filesystems.disks.{$this->minIODisk}.bucket") ?: 'bucket-name';
 
-        $addLocalMinIO = $this->exec("until (mc config host add local {$url} minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;", 30);
+        $addLocalMinIO = $this->exec("until (mc config host add local {$url} minioadmin minioadmin) do echo '...waiting...' && sleep 1; done;", 60);
 
         if (!Str::contains($addLocalMinIO, 'Added `local` successfully.')) {
             $this->fail('Could not configure MinIO server');


### PR DESCRIPTION
Adds `^8.5` to the PHP version constraint in `composer.json` and adds PHP 8.5 to the CI test matrix.